### PR TITLE
Ensure that the case name is properly URL escaped

### DIFF
--- a/spi/static/spi/spi-tools-dev.js
+++ b/spi/static/spi/spi-tools-dev.js
@@ -21,7 +21,7 @@ function spiTools_dev_addLink(pageTitle) {
 
 async function spiTools_dev_init(caseName) {
     const baseURL = 'https://spi-tools-dev.toolforge.org/spi/?caseName=';
-    window.open(encodeURI(baseURL + caseName));
+    window.open(baseURL + encodeURIComponent(caseName));
 };
 
 /**

--- a/spi/static/spi/spi-tools.js
+++ b/spi/static/spi/spi-tools.js
@@ -21,7 +21,7 @@ function spiTools_addLink(pageTitle) {
 
 async function spiTools_init(caseName) {
     const baseURL = 'https://spi-tools.toolforge.org/spi/?caseName=';
-    window.open(encodeURI(baseURL + caseName));
+    window.open(baseURL + encodeURIComponent(caseName));
 };
 
 /**


### PR DESCRIPTION
Use encodeURIComponent over encodeURI as the latter does not escape & characters amongst others that should be escaped in just the case name.

Fixes #205
Fixes #202
Fixes #220 